### PR TITLE
Main file cleanup

### DIFF
--- a/cgmerger/cgmerge.py
+++ b/cgmerger/cgmerge.py
@@ -248,6 +248,13 @@ def main():
                 ignore_regex=True,
             )
 
+        # now files that should go in order
+        if order is not None:
+            for f in order:
+                write_to_output_file(
+                    os.path.join(work_dir, f), output_file, exclude_line_regex
+                )
+
         for f in files_to_watch:
             if order is not None and f in order:
                 continue
@@ -258,10 +265,3 @@ def main():
             write_to_output_file(
                 os.path.join(work_dir, f), output_file, exclude_line_regex
             )
-
-        # now files that should go in order
-        if order is not None:
-            for f in order:
-                write_to_output_file(
-                    os.path.join(work_dir, f), output_file, exclude_line_regex
-                )

--- a/cgmerger/cgmerge.py
+++ b/cgmerger/cgmerge.py
@@ -94,43 +94,15 @@ config = configparser.ConfigParser(
 )
 
 
-def in_workdir(file_name: str):
-    return os.path.isdir(os.path.join(config["merger"]["workdir"], file_name))
-
-
-def check_output_exists():
-    if not os.path.exists(config["merger"]["output"]):
-        parser.error(
-            f"No \"{config['merger']['output']}\" file present in {os.getcwd()}"
-        )
-
-
-def check_header_exists():
-    if not os.path.exists(config["merger"]["header"]):
-        parser.error(
-            f"No \"{config['merger']['header']}\" file present in {os.getcwd()}"
-        )
-
-
-def check_footer_exists():
-    if not os.path.exists(config["merger"]["footer"]):
-        parser.error(
-            f"No \"{config['merger']['footer']}\" file present in {os.getcwd()}"
-        )
+def check_file_exists(file_path):
+    if not os.path.exists(file_path):
+        parser.error(f'No "{file_path}" file present in {os.getcwd()}')
 
 
 def check_workdir_exists():
     if not os.path.isdir(config["merger"]["workdir"]):
         parser.error(
             f"No \"{config['merger']['workdir']}\" directory present in {os.getcwd()}"
-        )
-
-
-def check_is_in_workdir(file_name: str):
-    if not in_workdir(file_name):
-        parser.error(
-            f'No "{file_name}" directory present in {os.getcwd()}'
-            f'/{config["merger"]["workdir"]}',
         )
 
 
@@ -219,18 +191,18 @@ def get_parameters_from_config():
     if "order" in config["merger"]:
         order = config["merger"]["order"].split(",")
 
-    check_output_exists()
+    check_file_exists(output_file_location)
     check_workdir_exists()
 
     if order is not None:
         for file_name in order:
-            check_is_in_workdir(file_name)
+            check_file_exists(os.path.join(work_dir, file_name))
 
     if header_file is not None:
-        check_header_exists()
+        check_file_exists(header_file)
 
     if footer_file is not None:
-        check_header_exists()
+        check_file_exists(footer_file)
 
     files_to_watch = [
         f for f in os.listdir(work_dir) if os.path.isfile(os.path.join(work_dir, f))

--- a/cgmerger/cgmerge.py
+++ b/cgmerger/cgmerge.py
@@ -201,6 +201,53 @@ def copy_parser_arguments_to_config(arguments: Namespace):
         config["merger"]["order"] = arguments.order
 
 
+def get_parameters_from_config():
+    order = None
+    output_file_location = config["merger"]["output"]
+    work_dir = config["merger"]["workdir"]
+    file_regex = re.compile(config["merger"]["file_regex"])
+    exclude_line_regex = re.compile(config["merger"]["exclude_line_regex"])
+    header_file = None
+    footer_file = None
+
+    if "header" in config["merger"]:
+        header_file = config["merger"]["header"]
+
+    if "footer" in config["merger"]:
+        footer_file = config["merger"]["header"]
+
+    if "order" in config["merger"]:
+        order = config["merger"]["order"].split(",")
+
+    check_output_exists()
+    check_workdir_exists()
+
+    if order is not None:
+        for file_name in order:
+            check_is_in_workdir(file_name)
+
+    if header_file is not None:
+        check_header_exists()
+
+    if footer_file is not None:
+        check_header_exists()
+
+    files_to_watch = [
+        f for f in os.listdir(work_dir) if os.path.isfile(os.path.join(work_dir, f))
+    ]
+
+    return (
+        order,
+        output_file_location,
+        work_dir,
+        file_regex,
+        exclude_line_regex,
+        header_file,
+        footer_file,
+        files_to_watch,
+    )
+
+
 def main():
     arguments = parser.parse_args()
     if os.path.exists("cgmerger.conf"):
@@ -227,40 +274,16 @@ def main():
         log_values()
         parser.exit(message="Config file created with listed values")
 
-    check_output_exists()
-
-    check_workdir_exists()
-
-    order = None
-    output_file_location = config["merger"]["output"]
-    work_dir = config["merger"]["workdir"]
-    file_regex = re.compile(config["merger"]["file_regex"])
-    exclude_line_regex = re.compile(config["merger"]["exclude_line_regex"])
-    header_file = None
-    footer_file = None
-
-    if "header" in config["merger"]:
-        header_file = config["merger"]["header"]
-
-    if "footer" in config["merger"]:
-        footer_file = config["merger"]["header"]
-
-    if "order" in config["merger"]:
-        order = config["merger"]["order"].split(",")
-
-    if order is not None:
-        for file_name in order:
-            check_is_in_workdir(file_name)
-
-    if header_file is not None:
-        check_header_exists()
-
-    if footer_file is not None:
-        check_header_exists()
-
-    files_to_watch = [
-        f for f in os.listdir(work_dir) if os.path.isfile(os.path.join(work_dir, f))
-    ]
+    (
+        order,
+        output_file_location,
+        work_dir,
+        file_regex,
+        exclude_line_regex,
+        header_file,
+        footer_file,
+        files_to_watch,
+    ) = get_parameters_from_config()
 
     with open(output_file_location, "w") as output_file:
         # all of the files, which are not in order

--- a/cgmerger/cgmerge.py
+++ b/cgmerger/cgmerge.py
@@ -17,12 +17,6 @@ parser.add_argument(
     help="Folder that will be searched for files to merge in output file",
 )
 parser.add_argument(
-    "--main",
-    type=str,
-    help="main file in workdir that will be copied the last (main loop should be "
-    "placed in here)",
-)
-parser.add_argument(
     "--header",
     type=str,
     help="File from which the top part of output file will be copied (you should put "
@@ -78,7 +72,6 @@ config = configparser.ConfigParser(
     defaults={
         "output": "codingame.volatile.py",
         "workdir": "codingame/",
-        "main": "main.py",
         "file_regex": ".*",
         "exclude_line_regex": "^from codingame\.|^import codingame|^from \.|^import \.",
         "comment": "#",
@@ -160,7 +153,6 @@ def log_values():
     print("")
     print("output: ", config["merger"].get("output", "none"))
     print("workdir: ", config["merger"].get("workdir", "none"))
-    print("main: ", config["merger"].get("main", "none"))
     print("file_regex: ", config["merger"].get("file_regex", "none"))
     print("exclude_line_regex: ", config["merger"].get("exclude_line_regex", "none"))
     print("header: ", config["merger"].get("header", "none"))
@@ -193,8 +185,6 @@ def main():
         config["merger"]["output"] = arguments.output
     if arguments.workdir is not None:
         config["merger"]["workdir"] = arguments.workdir
-    if arguments.main is not None:
-        config["merger"]["main"] = arguments.main
     if arguments.header is not None:
         config["merger"]["header"] = arguments.header
     if arguments.comment is not None:
@@ -216,7 +206,6 @@ def main():
 
     order = None
     output_file_location = config["merger"]["output"]
-    main_file = config["merger"]["main"]
     work_dir = config["merger"]["workdir"]
     file_regex = re.compile(config["merger"]["file_regex"])
     exclude_line_regex = re.compile(config["merger"]["exclude_line_regex"])
@@ -240,7 +229,7 @@ def main():
     ]
 
     with open(output_file_location, "w") as output_file:
-        # all of the files, which are not in main, are are not in order
+        # all of the files, which are not in order
         if header_file is not None:
             write_to_output_file(
                 header_file,
@@ -251,9 +240,6 @@ def main():
             )
 
         for f in files_to_watch:
-            if f == main_file:
-                continue
-
             if order is not None and f in order:
                 continue
 
@@ -267,17 +253,6 @@ def main():
         # now files that should go in order
         if order is not None:
             for f in order:
-                if f == main_file:
-                    continue
-
                 write_to_output_file(
                     os.path.join(work_dir, f), output_file, exclude_line_regex
                 )
-
-        # Main will always be the last one
-        write_to_output_file(
-            os.path.join(work_dir, main_file),
-            output_file,
-            exclude_line_regex,
-            disable_headers=True,
-        )

--- a/cgmerger/cgmerge.py
+++ b/cgmerger/cgmerge.py
@@ -147,6 +147,7 @@ def log_values():
     print("file_regex: ", config["merger"].get("file_regex", "none"))
     print("exclude_line_regex: ", config["merger"].get("exclude_line_regex", "none"))
     print("header: ", config["merger"].get("header", "none"))
+    print("footer: ", config["merger"].get("footer", "none"))
     print("comment: ", config["merger"].get("comment", "none"))
     print("separator_start: ", config["merger"].get("separator_start", "none"))
     print("separator_end: ", config["merger"].get("separator_end", "none"))
@@ -186,7 +187,7 @@ def get_parameters_from_config():
         header_file = config["merger"]["header"]
 
     if "footer" in config["merger"]:
-        footer_file = config["merger"]["header"]
+        footer_file = config["merger"]["footer"]
 
     if "order" in config["merger"]:
         order = config["merger"]["order"].split(",")
@@ -199,10 +200,10 @@ def get_parameters_from_config():
             check_file_exists(os.path.join(work_dir, file_name))
 
     if header_file is not None:
-        check_file_exists(header_file)
+        check_file_exists(os.path.join(work_dir, header_file))
 
     if footer_file is not None:
-        check_file_exists(footer_file)
+        check_file_exists(os.path.join(work_dir, footer_file))
 
     files_to_watch = [
         f for f in os.listdir(work_dir) if os.path.isfile(os.path.join(work_dir, f))
@@ -261,7 +262,7 @@ def main():
         # all of the files, which are not in order
         if header_file is not None:
             write_to_output_file(
-                header_file,
+                os.path.join(work_dir, header_file),
                 output_file,
                 exclude_line_regex,
                 disable_headers=True,
@@ -271,12 +272,25 @@ def main():
         # now files that should go in order
         if order is not None:
             for f in order:
+
+                if f == header_file:
+                    continue
+
+                if f == footer_file:
+                    continue
+
                 write_to_output_file(
                     os.path.join(work_dir, f), output_file, exclude_line_regex
                 )
 
         for f in files_to_watch:
             if order is not None and f in order:
+                continue
+
+            if f == header_file:
+                continue
+
+            if f == footer_file:
                 continue
 
             if not file_regex.search(f):
@@ -288,9 +302,8 @@ def main():
 
         if footer_file is not None:
             write_to_output_file(
-                footer_file,
+                os.path.join(work_dir, footer_file),
                 output_file,
                 exclude_line_regex,
                 disable_headers=True,
-                ignore_regex=True,
             )

--- a/cgmerger/cgmerge.py
+++ b/cgmerger/cgmerge.py
@@ -17,6 +17,12 @@ parser.add_argument(
     help="Folder that will be searched for files to merge in output file",
 )
 parser.add_argument(
+    "--order",
+    type=str,
+    help="Forcing the order of files copied from the workdir (use comma-separated "
+    "file names)",
+)
+parser.add_argument(
     "--header",
     type=str,
     help="File from which the top part of output file will be copied (you should put "
@@ -153,6 +159,7 @@ def log_values():
     print("")
     print("output: ", config["merger"].get("output", "none"))
     print("workdir: ", config["merger"].get("workdir", "none"))
+    print("order: ", config["merger"].get("order", "none"))
     print("file_regex: ", config["merger"].get("file_regex", "none"))
     print("exclude_line_regex: ", config["merger"].get("exclude_line_regex", "none"))
     print("header: ", config["merger"].get("header", "none"))
@@ -189,6 +196,8 @@ def main():
         config["merger"]["header"] = arguments.header
     if arguments.comment is not None:
         config["merger"]["comment"] = arguments.comment
+    if arguments.order is not None:
+        config["merger"]["order"] = arguments.order
 
     if arguments.debug:
         log_values()


### PR DESCRIPTION
Changed a LOT of stuff to fix up #4 and make it more logical.

Right now, only files that are in ``workdir`` are considered (or rather also - files in relation to the workdir, you can still define header in main folder if you write relative path ``../headerfile.py``).

I will create new template project and re-adjust everything.

@Nerwosolek - after this merge is made - there is no ``main`` file anymore. You can define a ``header`` file and a ``footer`` file (I think this is more intuitive than ``main``). Also - this ``footer`` file is optional.

Overall the new order in which the files are copied from the ``workdir`` is:
1. Header file
2. Files set in ``order`` property/argument (separated by comma)
3. All other files caught by the regex
4. Footer file