### PR TITLE
Remove parts of line

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ from those languages and you should be able to use the script:
 
 - ``C#`` sample project: https://github.com/ajakubo1/CGmerger-examples/tree/main/default-csharp
 - ``python`` sample project: https://github.com/ajakubo1/CGmerger-examples/tree/main/default-python
+- ``typescript`` sample project: https://github.com/ajakubo1/CGmerger-examples/tree/main/default-typescript
 
 Please - share your successful setup of the script by opening a PR to https://github.com/ajakubo1/CGmerger-examples/
 
@@ -98,3 +99,7 @@ For re-adjusting the script for different languages, you probably need to re-adj
  ``workdir`` should be copied to ``output`` file. By default, the command will
  copy the contents of all of the files in that folder. You can change it to target
  different file types (e.g. ``.*.cs`` files instead of ``.*.py`` files)
+- ``remove_parts_regex`` (**optional**) - this is regex used when script starts to
+ copy file contents line-by-line to replace some of the unneeded strings. E.g. in 
+ ``.ts`` scripts lines starting with "export" should be reformatted in such a way
+ that we remove that export part. This can be done by setting ``remove_parts_regex`` to ``^export``.

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -30,6 +30,7 @@ class FileDoesntExist(unittest.TestCase):
         args_mock = Mock()
         args_mock.file_regex = None
         args_mock.exclude_line_regex = None
+        args_mock.remove_parts_regex = None
         args_mock.output = None
         args_mock.workdir = None
         args_mock.basedir = "./"
@@ -566,6 +567,53 @@ class FileDoesntExist(unittest.TestCase):
                     '\n// file "codingame/one.cs" -----------------------------------------------------\n'
                 ),
                 call().write("static void Main(string[] args)"),
+                call().write(
+                    '\n\n\n// end of file "codingame/one.cs" ==============================================\n'
+                ),
+            ],
+        )
+
+    @patch("cgmerger.cgmerge.parser")
+    @patch("cgmerger.cgmerge.os.path.isfile")
+    @patch("cgmerger.cgmerge.os.path.isdir")
+    @patch("cgmerger.cgmerge.os.path.getsize")
+    @patch("cgmerger.cgmerge.os.listdir")
+    @patch("cgmerger.cgmerge.chardet.detect")
+    def test_replace_part_content(
+        self, detect, listdir, getsize, is_dir, path_exists, parser
+    ):
+        open = mock_open(Mock(), read_data="export const weee = () => {}",)
+        detect.return_value = {"encoding": "utf-8"}
+        getsize.return_value = 1
+        path_exists.return_value = True
+        is_dir.return_value = True
+        listdir.return_value = ["one.cs"]
+        args_mock, _ = self.get_default_setup(parser)
+        args_mock.remove_parts_regex = "^export"
+        args_mock.output = "codingame.volatile.cs"
+        args_mock.comment = "//"
+        with patch("cgmerger.cgmerge.open", open):
+            main()
+
+        calls = list(
+            filter(
+                lambda line: line != call().__enter__()
+                and line != call().__exit__(None, None, None)
+                and line != call().read(1)
+                and line != call().readlines(),
+                open.mock_calls,
+            )
+        )
+        self.assertListEqual(
+            calls,
+            [
+                call("./codingame.volatile.cs", "w"),
+                call("./codingame/one.cs", "rb"),
+                call("./codingame/one.cs", "r", encoding="utf-8"),
+                call().write(
+                    '\n// file "codingame/one.cs" -----------------------------------------------------\n'
+                ),
+                call().write(" const weee = () => {}"),
                 call().write(
                     '\n\n\n// end of file "codingame/one.cs" ==============================================\n'
                 ),


### PR DESCRIPTION
Turns out that when I wrote a ``ts`` example - I noticed one more feature is needed - removing parts of the lines that we copy to ``output``.